### PR TITLE
remove nonexistent agent imports

### DIFF
--- a/src/matharena/solvers/__init__.py
+++ b/src/matharena/solvers/__init__.py
@@ -2,10 +2,6 @@ from .solver_response import SolverResponse
 from .base_solver import BaseSolver
 from .base_agent import BaseAgent
 from .pure_model_solver import PureModelSolver
-from .euler_agent import EulerAgent
-from .euler_base_agent import BaseEulerAgent
 from .selfcheck_agent import SelfcheckAgent
-from .math_agent import MathAgent
-from .math_static_agent import StaticMathAgent
 from .deepseek_math import DeepSeekMathAgent
 from .agent_pool import AgentPool


### PR DESCRIPTION
Looks like a couple nonexistent imports were added in 1b2c2ed.  They should be removed until they are implemented.